### PR TITLE
Simplified paths for loading

### DIFF
--- a/src/bayesian_neural_decoder/data_loader.py
+++ b/src/bayesian_neural_decoder/data_loader.py
@@ -11,24 +11,22 @@ class DataLoader:
     
     @classmethod
     def load(cls, 
-             dataset_path: str = "../../../datasets/decoder_data", 
-             results_filename: str = "clusterless_spike_decoding_results.pkl") -> dict:
+             results_path: str = "../../../datasets/decoder_data/clusterless_spike_decoding_results.pkl") -> dict:
         
-        decoding_results_filename = os.path.join(dataset_path, results_filename)
-        if not os.path.exists(decoding_results_filename):
-            raise Exception("Dataset incorrect. Missing decoding results file.")
+        if not os.path.exists(results_path):
+            raise Exception("Decoding results path incorrect.")
 
-        with open(decoding_results_filename, "rb") as f:
+        with open(results_path, "rb") as f:
             results = pickle.load(f)
             decoding_results = results["decoding_results"]
             position_bins = decoding_results.position.to_numpy()[np.newaxis]
             predictions = decoding_results.acausal_posterior.to_numpy()
             position_data = results["linear_position"]
-            model_inputs = results["model_inputs"]
+            spikes = results["spikes"]
 
         return {
             "position_data": position_data,
-            "model_inputs": model_inputs,
-            "decoding_results": predictions,
+            "spikes": spikes,
+            "predictions": predictions,
             "position_bins": position_bins
         }

--- a/src/bayesian_neural_decoder/decoder.py
+++ b/src/bayesian_neural_decoder/decoder.py
@@ -6,6 +6,7 @@ from replay_trajectory_classification.likelihoods.multiunit_likelihood import es
 
 from .likelihood import LIKELIHOOD_FUNCTION
 
+import os
 import numpy as np
 import pickle as pkl
 import cupy as cp
@@ -19,6 +20,10 @@ class Decoder():
     
     @classmethod
     def load(cls, filename: str):
+        
+        if not os.path.exists(filename):
+            raise Exception("Decoder path incorrect.")
+        
         with open(filename, "rb") as f:
             return cls(pkl.load(f))
 


### PR DESCRIPTION
# Simplified paths for loading

- **Updated data loader to use only a single results path as an argument**
- **Added filename check to ensure path to decoder model exists when loading**
